### PR TITLE
Fixed call to subprocess.Popen()

### DIFF
--- a/command-control-rest-daemon.py
+++ b/command-control-rest-daemon.py
@@ -48,10 +48,12 @@ def msg(msg):
 
 def execute_command(cmd):
     print("execute: {}".format(cmd))
+    args = cmd['cmd'].split()
     use_shell = False
     if 'shell' in cmd and cmd['shell'] == True:
+        args = cmd['cmd']
         use_shell = True
-    process = subprocess.Popen(cmd['cmd'].split(), shell=use_shell)
+    process = subprocess.Popen(args, shell=use_shell)
     if 'wait' in cmd and cmd['wait'] == True:
         process.wait()
 


### PR DESCRIPTION
From docs.python.org:
"The *shell* argument (which defaults to `False`) specifies whether to use the shell as the program to execute.
 If *shell* is `True`, it is recommended to pass *args* as a string rather than as a sequence."